### PR TITLE
Fix turning angle calculation

### DIFF
--- a/Assets/Scripts/Pathfinding/Hybrid A star/HybridAStar.cs
+++ b/Assets/Scripts/Pathfinding/Hybrid A star/HybridAStar.cs
@@ -454,7 +454,7 @@ namespace PathfindingForVehicles
                     float alpha = steeringAngles[j];
 
                     //Turning angle
-                    float beta = (driveDistance / carData.WheelBase) * Mathf.Tan(alpha);
+                    float beta = (driveDistance / carData.WheelBase) * Mathf.Sin(alpha);
 
                     //Simulate the car driving forward by using a mathematical car model
                     Vector3 newRearWheelPos = VehicleSimulationModels.CalculateNewPosition(heading, beta, driveDistance, currentNode.rearWheelPos);


### PR DESCRIPTION
That one Tan() function violates the turning radius of the vehicle.

Here is a simple fix. The math is following:
$turnRadius = wheelBase / Sin(steeringAngle)$
$turnAngle = arcLength / turnRadius$

So,
$turnAngle = arcLength / wheelBase * Sin(steeringAngle)$